### PR TITLE
Cronjob Setup & Article publishing (#62)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,9 @@ chargebee==2.3.7
 cryptography==2.0.3
 decorator==4.1.2
 Django==1.11.6
+django-common-helpers==0.9.1
 django-countries==4.5
+django-cron==0.5.0
 django-easycart==0.4.0
 django-extensions==1.7.5
 django-guardian==1.4.9

--- a/seite/cron.py
+++ b/seite/cron.py
@@ -1,0 +1,23 @@
+from django_cron import CronJobBase, Schedule
+from Workflow.utils import trelloToSQL, publish
+
+# Add to crontab: */5 * * * * cd /home/scholarium/scholarium_production && source venv/bin/activate && python manage.py runcrons
+# TODO: Check if log output is created.
+
+class cron_t2sql(CronJobBase):
+    RUN_EVERY_MINS = 60
+    
+    schedule = Schedule(run_every_mins=RUN_EVERY_MINS)
+    code = 'Trello to SQL Cronjob'
+    
+    def do(self):
+        trelloToSQL()
+
+class cron_publish(CronJobBase):
+    RUN_EVERY_MINS = 10
+
+    schedule = Schedule(run_every_mins=RUN_EVERY_MINS)
+    code = 'Publish article Cronjob'
+
+    def do(self):
+        publish()

--- a/seite/settings.py
+++ b/seite/settings.py
@@ -67,6 +67,7 @@ INSTALLED_APPS = [
     'django.contrib.humanize',
     'easycart',
     'django_countries',
+    'django_cron',
 ]
 
 MIDDLEWARE_CLASSES = [
@@ -78,6 +79,7 @@ MIDDLEWARE_CLASSES = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
+
 
 ROOT_URLCONF = 'seite.urls'
 
@@ -226,3 +228,12 @@ PAYPAL_CLIENT_ID = 'AasKeJoihSdkebF5q7QCuubWoIpnlZiV5vfklRN6onwfU9AJYOwXJ5HvDO-P
 PAYPAL_CLIENT_SECRET = 'EI3An34Ea1-D5oKS59QwAI0mGu8ELZRT3m9YxPKfRCdoGlqlYL3Oqc8jlelBMpebtxXsKBjO4GCZmnOz' #get_env_variable('PAYPAL_CLIENT_SECRET')
 
 HOSTNAME = 'https://scholarium.at'
+
+## Cron
+CRON_CLASSES = [
+    'seite.cron.cron_t2sql',
+    'seite.cron.cron_publish',
+]
+
+# Release period in days
+RELEASE_PERIOD = 6

--- a/seite/settings.py
+++ b/seite/settings.py
@@ -176,7 +176,7 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-
+ 
 # Internationalization
 # https://docs.djangoproject.com/en/1.9/topics/i18n/
 


### PR DESCRIPTION
TODO: Cronjob Setup auf Server:
`*/5 * * * * cd /home/scholarium/scholarium_production && source venv/bin/activate && python manage.py runcrons`
@rahim-t Wir sollten Artikel trotzdem manuell durchschauen, bei den letzten war immer irgendetwas kaputt.