### PR TITLE
Unnötigen local_setting import entfernt

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -3,10 +3,7 @@ import os
 import sys
 
 if __name__ == "__main__":
-    try:
-        os.environ.setdefault("DJANGO_SETTINGS_MODULE", "seite.local_settings")
-    except ModuleNotFoundError:
-        os.environ.setdefault("DJANGO_SETTINGS_MODULE", "seite.settings")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "seite.settings")
         
     from django.core.management import execute_from_command_line
 


### PR DESCRIPTION
Siehe https://github.com/valuehack/scholarium.at/issues/58:
Lokal ausführen mit --settings='seite.local_settings' wenn locale Settings genutzt werden sollen. Sollten wir vielleicht ins Readme schreiben? Ich kann mir vorstellen, dass das potentiell verwirrende Fehler hervorruft, wenn er MEDIA_ROOT usw nicht findet.