### PR TITLE
kopfleiste_nutzer: add link to admin for staff

### DIFF
--- a/Grundgeruest/templates/Grundgeruest/kopfleiste_nutzer.html
+++ b/Grundgeruest/templates/Grundgeruest/kopfleiste_nutzer.html
@@ -51,3 +51,8 @@
     >Warenkorb <span class="badge">{{ cart.item_count }}</span>
   </a>
 </div>
+{% if request.user.is_staff %}
+  <div class="login_button">
+    <a href="{% url 'admin:index' %}">Datenbank (Admin)</a>
+  </div>
+{% endif %}


### PR DESCRIPTION
Kleine Hilfe, um nicht in die Adresszeile klicken zu müssen, wenn man zum Admin-Panel möchte.