### PR TITLE
Integrated Analytics

### DIFF
--- a/Grundgeruest/templates/Grundgeruest/ilja.html
+++ b/Grundgeruest/templates/Grundgeruest/ilja.html
@@ -12,6 +12,12 @@
     {% endblock head %}
   </head>
   <body>
+
+    {% load google_analytics_tags %}
+    <div style="display:none">
+        <img src="{% google_analytics %}" width="0" height="0" />
+    </div>
+
     <header class="header">
     {% block kopfleiste %}
       <div style="background-color: red; height: 30px; margin-bottom: -30px; text-align: right">hallo</div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,11 @@
+amqp==1.4.9
+anyjson==0.3.3
 appdirs==1.4.3
 asn1crypto==0.23.0
 bcrypt==3.1.3
+beautifulsoup4==4.6.0
+billiard==3.3.0.23
+celery==3.1.26.post2
 certifi==2017.7.27.1
 cffi==1.9.1
 chardet==3.0.4
@@ -8,11 +13,13 @@ chargebee==2.3.7
 cryptography==2.0.3
 decorator==4.1.2
 Django==1.11.6
+django-celery==3.2.2
 django-common-helpers==0.9.1
 django-countries==4.5
 django-cron==0.5.0
 django-easycart==0.4.0
 django-extensions==1.7.5
+django-google-analytics-app==4.3.0
 django-guardian==1.4.9
 django-userena==2.0.1
 docutils==0.13.1
@@ -25,6 +32,7 @@ ipdb==0.10.3
 ipython==6.2.1
 ipython-genutils==0.2.0
 jedi==0.11.0
+kombu==3.0.37
 lxml==4.0.0
 mysql-connector==2.1.4
 oauthlib==2.0.4

--- a/seite/settings.py
+++ b/seite/settings.py
@@ -69,6 +69,7 @@ INSTALLED_APPS = [
     'easycart',
     'django_countries',
     'django_cron',
+    'google_analytics',
 ]
 
 MIDDLEWARE_CLASSES = [
@@ -241,3 +242,7 @@ CRON_CLASSES = [
 
 # Release period in days
 RELEASE_PERIOD = 6
+
+GOOGLE_ANALYTICS = {
+    'google_analytics_id': 'UA-117190689-1',
+}

--- a/seite/urls.py
+++ b/seite/urls.py
@@ -27,6 +27,7 @@ from Produkte.models import Spendenstufe
 urlpatterns = [
     url(r'^admin/doc/', include('django.contrib.admindocs.urls')),
     url(r'^admin/', admin.site.urls),
+    url(r'^djga/', include('google_analytics.urls')),
     url(r'^fragen/',
         TemplateMitMenue.as_view(
             template_name='Gast/fragen.html'),


### PR DESCRIPTION
per https://github.com/praekelt/django-google-analytics
- Celery wird nicht benutzt (ist optional), packet hat nut dependency
- Analytics ID ist sichtbar, kann aber eh im sourcecode eingesehen werden. Man kann sich im Notfall über die Analytics Einstellungen schützen.